### PR TITLE
新增 font-weight regular 400 的 utility

### DIFF
--- a/assets/scss/utils/_utilities.scss
+++ b/assets/scss/utils/_utilities.scss
@@ -357,6 +357,7 @@ $utilities: map-merge(( // scss-docs-start utils-vertical-align
       values: (lighter: $font-weight-lighter,
         light: $font-weight-light,
         normal: $font-weight-normal,
+        regular: $font-weight-regular,
         medium: $font-weight-medium,
         semibold: $font-weight-semibold,
         bold: $font-weight-bold,

--- a/assets/scss/utils/_variables.scss
+++ b/assets/scss/utils/_variables.scss
@@ -660,7 +660,7 @@ $font-size-lg: $font-size-base * 1.25 !default;
 
 $font-weight-lighter: lighter !default;
 $font-weight-light: 300 !default;
-// $font-weight-normal: 400 !default;
+$font-weight-regular: 400;
 $font-weight-normal: 100 !default; //customize
 $font-weight-medium: 500 !default;
 $font-weight-semibold: 600 !default;


### PR DESCRIPTION
有新增
`$font-weight-regular: 400;` 在 variables.scss 之中，
並且更新 utilities.scss 在 font-weight 之中多輸出 `fw-regular` 的 class 供使用